### PR TITLE
PAN-1907: freeze sdist dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,20 @@ jobs:
         run: |
           poetry self add poetry-plugin-freeze
           poetry freeze-wheel
+          # Copy the file "METADATA" from the wheel to "PKG-INFO" in the sdist
+          # Unzip wheel and sdist
+          mkdir tmp
+          cp dist/*.whl tmp/wheel.zip
+          unzip tmp/wheel.zip -d tmp/wheel/
+          # Untar sdist
+          mkdir tmp/sdist
+          tar -xzf dist/*.tar.gz -C tmp/sdist/
+          # Copy the file
+          cp tmp/wheel/*.dist-info/METADATA tmp/sdist/*/PKG-INFO
+          # Tar the sdist again
+          tar -czf dist/$(ls dist | grep .tar.gz) -C tmp/sdist/ .
+          # Remove the temporary directories
+          rm -rf tmp
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ find.sh
 local/
 .coverage
 requirements.txt
+tmp


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds the frozen dependencies for sdist to the release workflow

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #PAN-1907
- Closes #

## QA Instructions
Run a release

## [optional] Are there any post deployment tasks we need to perform?
Run a release